### PR TITLE
Improve Colab support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
-# dwoqd
+# PDF Analyzer Automation
+
+This repository contains a script to convert a PDF into JPG files, analyze each page using the OpenAI API, and append the images and analysis to a Google Docs document.
+
+## Requirements
+
+- Python 3.11+
+- `pdftoppm` from Poppler (install with `apt-get install poppler-utils` on Debian/Ubuntu)
+- Python packages listed in `requirements.txt`
+- Google service account credentials with access to Google Docs
+- `OPENAI_API_KEY` environment variable
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python analyze_pdf.py --pdf path/to/file.pdf \
+                      --google-credentials path/to/credentials.json \
+                      --doc-id YOUR_GOOGLE_DOC_ID
+```
+
+The script will save JPG files in the `output_images` directory, analyze each page, and append the images and their descriptions to the specified Google Doc.
+
+## Web Interface
+
+The repository includes a Flask application that lets you upload a PDF and analyze it in the browser. Processed PDFs are stored in a history page so you can review the results and decide when to save them.
+
+Run the server:
+
+```bash
+python web_app.py
+```
+
+Open `http://localhost:8000` in your browser and fill out the form with the PDF file, Google service account JSON, OpenAI API key, and optional prompt. After processing, visit the **History** page to see the results. From there you can choose a document title and save the images and descriptions to a new Google Doc whenever you need.
+
+### Running in Google Colab
+
+In Google Colab you can expose the Flask server using `google.colab.output`.
+Some environments may not provide `serve_kernel_port`, so check for it first:
+
+```python
+from google.colab import output
+if hasattr(output, "serve_kernel_port"):
+    url = output.serve_kernel_port(8000)
+    print(f"Open the web interface at: {url}")
+!python web_app.py
+```
+
+This will provide a link in the cell output that opens the web interface.
+
+### Google Colab에서 자세히 실행하기
+
+1. 새 Colab 노트북에서 저장소를 가져오고 필요한 패키지를 설치합니다.
+
+   ```bash
+   !git clone <저장소 URL>
+   %cd dwoqd
+   !pip install -r requirements.txt
+   !apt-get -y install poppler-utils
+   ```
+
+2. 다음 코드를 실행해 Flask 서버를 노트북 외부에서 접근할 수 있도록 노출합니다. 일부 환경에서는 `serve_kernel_port`가 없을 수 있으므로 조건을 확인합니다.
+
+   ```python
+   from google.colab import output
+   if hasattr(output, "serve_kernel_port"):
+       url = output.serve_kernel_port(8000)
+       print(f"Open the web interface at: {url}")
+   !python web_app.py
+   ```
+
+3. 셀 출력에 나타나는 링크를 클릭하면 웹 인터페이스가 열립니다. 여기서 PDF 파일,
+   Google 서비스 계정 JSON, OpenAI API 키, 프롬프트를 한 번에 입력하면 됩니다.
+   분석이 끝나면 **History** 페이지에서 결과를 확인하고 원하는 시점에
+   Google Docs로 저장할 수 있습니다.

--- a/analyze_pdf.py
+++ b/analyze_pdf.py
@@ -1,0 +1,106 @@
+import os
+import io
+import base64
+import argparse
+from pdf2image import convert_from_path
+from googleapiclient.discovery import build
+from google.oauth2 import service_account
+import openai
+
+
+def pdf_to_images(pdf_path, output_dir):
+    os.makedirs(output_dir, exist_ok=True)
+    images = convert_from_path(pdf_path)
+    image_paths = []
+    for i, img in enumerate(images):
+        out_path = os.path.join(output_dir, f"page_{i+1}.jpg")
+        img.save(out_path, 'JPEG')
+        image_paths.append(out_path)
+    return image_paths
+
+
+def call_openai(image_path, prompt):
+    with open(image_path, 'rb') as f:
+        b64 = base64.b64encode(f.read()).decode('utf-8')
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}}
+            ]
+        }
+    ]
+    response = openai.chat.completions.create(
+        model="gpt-4o",
+        messages=messages,
+        max_tokens=300,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def get_docs_service(credentials_path):
+    creds = service_account.Credentials.from_service_account_file(
+        credentials_path,
+        scopes=['https://www.googleapis.com/auth/documents']
+    )
+    return build('docs', 'v1', credentials=creds)
+
+
+def append_image_and_text(service, doc_id, image_path, text):
+    with open(image_path, 'rb') as f:
+        image_content = f.read()
+
+    requests = [
+        {
+            'insertInlineImage': {
+                'location': {
+                    'endOfSegmentLocation': {}
+                },
+                'objectSize': {
+                    'height': {'magnitude': 500, 'unit': 'PT'},
+                    'width': {'magnitude': 400, 'unit': 'PT'}
+                },
+                'uri': 'data:image/jpeg;base64,' + base64.b64encode(image_content).decode('utf-8')
+            }
+        },
+        {
+            'insertText': {
+                'endOfSegmentLocation': {},
+                'text': '\n' + text + '\n\n'
+            }
+        }
+    ]
+    service.documents().batchUpdate(documentId=doc_id, body={'requests': requests}).execute()
+
+
+def create_document(service, title):
+    """Create a new Google Doc and return its document ID."""
+    doc = service.documents().create(body={'title': title}).execute()
+    return doc.get('documentId')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Analyze PDF pages with OpenAI and save results to Google Docs.')
+    parser.add_argument('--pdf', required=True, help='Input PDF file')
+    parser.add_argument('--output-dir', default='output_images', help='Directory to save JPG pages')
+    parser.add_argument('--prompt', default='Describe the page', help='Prompt to analyze each page')
+    parser.add_argument('--google-credentials', required=True, help='Path to Google service account JSON credentials')
+    parser.add_argument('--doc-id', required=True, help='Google Docs document ID to append results to')
+    args = parser.parse_args()
+
+    openai.api_key = os.environ.get('OPENAI_API_KEY')
+    if not openai.api_key:
+        raise RuntimeError('OPENAI_API_KEY environment variable not set')
+
+    service = get_docs_service(args.google_credentials)
+
+    image_paths = pdf_to_images(args.pdf, args.output_dir)
+    for img_path in image_paths:
+        description = call_openai(img_path, args.prompt)
+        append_image_and_text(service, args.doc_id, img_path, description)
+        print(f'Processed {img_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pdf2image
+openai
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib
+Flask

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,164 @@
+from flask import Flask, request, render_template_string, redirect, url_for
+import os
+import tempfile
+import base64
+
+from analyze_pdf import (
+    pdf_to_images,
+    call_openai,
+    get_docs_service,
+    append_image_and_text,
+    create_document,
+)
+
+
+app = Flask(__name__)
+
+history = []
+
+
+INDEX_HTML = """
+<!doctype html>
+<title>PDF Analyzer</title>
+<h1>Upload PDF</h1>
+<form method="post" enctype="multipart/form-data">
+  <label>PDF File: <input type="file" name="pdf" required></label><br>
+  <label>Google Credentials JSON: <input type="file" name="credentials" required></label><br>
+  <label>OpenAI API Key: <input type="text" name="openai_api_key" required></label><br>
+  <label>Prompt:<br>
+    <textarea name="prompt" rows="4" cols="50">Describe the page</textarea>
+  </label><br>
+  <input type="submit" value="Analyze">
+</form>
+<p>{{ message }}</p>
+<p><a href="{{ url_for('history_page') }}">History</a></p>
+"""
+
+
+HISTORY_HTML = """
+<!doctype html>
+<title>History</title>
+<h1>Analysis History</h1>
+<ul>
+{% for item in history %}
+  <li><a href="{{ url_for('view_item', item_id=item.id) }}">{{ item.title }}</a></li>
+{% endfor %}
+</ul>
+<p><a href="{{ url_for('index') }}">Upload another PDF</a></p>
+"""
+
+
+DETAIL_HTML = """
+<!doctype html>
+<title>{{ item.title }}</title>
+<h1>{{ item.title }}</h1>
+{% for entry in item.results %}
+  <div>
+    <img src="data:image/jpeg;base64,{{ entry.img_b64 }}" width="400"><br>
+    <pre>{{ entry.description }}</pre>
+  </div>
+  <hr>
+{% endfor %}
+<form method="post" action="{{ url_for('save', item_id=item.id) }}">
+  <label>Document title: <input type="text" name="title" value="{{ item.title }}"></label>
+  <input type="submit" value="Save to Google Docs">
+</form>
+<p>{{ message }}</p>
+<p><a href="{{ url_for('history_page') }}">Back to history</a></p>
+"""
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    message = ''
+    if request.method == 'POST':
+        pdf_file = request.files.get('pdf')
+        cred_file = request.files.get('credentials')
+        openai_key = request.form.get('openai_api_key')
+        prompt = request.form.get('prompt', 'Describe the page')
+
+        if pdf_file and cred_file and openai_key:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                pdf_path = os.path.join(tmpdir, 'input.pdf')
+                pdf_file.save(pdf_path)
+                creds_json = cred_file.read().decode('utf-8')
+
+                os.environ['OPENAI_API_KEY'] = openai_key
+
+                results = []
+                for img_path in pdf_to_images(pdf_path, tmpdir):
+                    description = call_openai(img_path, prompt)
+                    with open(img_path, 'rb') as img_f:
+                        img_b64 = base64.b64encode(img_f.read()).decode('utf-8')
+                    results.append({'img_b64': img_b64, 'description': description})
+
+            item_id = len(history)
+            history.append({
+                'id': item_id,
+                'title': os.path.basename(pdf_file.filename),
+                'prompt': prompt,
+                'results': results,
+                'credentials_json': creds_json,
+            })
+            return redirect(url_for('view_item', item_id=item_id))
+        else:
+            message = 'Missing required fields.'
+    return render_template_string(INDEX_HTML, message=message)
+
+
+@app.route('/history')
+def history_page():
+    return render_template_string(HISTORY_HTML, history=history)
+
+
+@app.route('/history/<int:item_id>')
+def view_item(item_id):
+    item = next((i for i in history if i['id'] == item_id), None)
+    if not item:
+        return 'Not found', 404
+    return render_template_string(DETAIL_HTML, item=item, message='')
+
+
+@app.route('/save/<int:item_id>', methods=['POST'])
+def save(item_id):
+    item = next((i for i in history if i['id'] == item_id), None)
+    if not item:
+        return 'Not found', 404
+
+    title = request.form.get('title', item['title'])
+
+    with tempfile.NamedTemporaryFile('w+', delete=False) as cred_tmp:
+        cred_tmp.write(item['credentials_json'])
+        cred_tmp.flush()
+        service = get_docs_service(cred_tmp.name)
+
+    doc_id = create_document(service, title)
+
+    for entry in item['results']:
+        with tempfile.NamedTemporaryFile(suffix='.jpg') as img_tmp:
+            img_tmp.write(base64.b64decode(entry['img_b64']))
+            img_tmp.flush()
+            append_image_and_text(service, doc_id, img_tmp.name, entry['description'])
+
+    message = f'Saved to Google Docs: {doc_id}'
+    return render_template_string(DETAIL_HTML, item=item, message=message)
+
+
+if __name__ == '__main__':
+    # Running inside Google Colab requires a special handler to expose the
+    # Flask app. When `google.colab` is available we attempt to use
+    # `output.serve_kernel_port` so users can access the web UI via a link.
+    try:
+        from google.colab import output  # type: ignore
+        if hasattr(output, "serve_kernel_port"):
+            url = output.serve_kernel_port(
+                8000, lambda: app.run(host="0.0.0.0", port=8000)
+            )
+            print(f"Access the web UI at: {url}", flush=True)
+        else:
+            # If the attribute is missing just run the server normally.
+            app.run(host="0.0.0.0", port=8000)
+    except Exception:
+        # Fall back to the normal Flask dev server when not in Colab.
+        app.run(host="0.0.0.0", port=8000)
+


### PR DESCRIPTION
## Summary
- document conditional use of `serve_kernel_port` in README
- gracefully handle missing `serve_kernel_port` in `web_app.py`
- print the URL returned by `serve_kernel_port` so users see it in Colab

## Testing
- `python -m py_compile analyze_pdf.py web_app.py`
- `python analyze_pdf.py -h`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68534f1ff96c8321b27d3c4a2fc522bc